### PR TITLE
Add Nifty options scalping bot

### DIFF
--- a/main_options.py
+++ b/main_options.py
@@ -1,0 +1,49 @@
+"""main_options.py
+
+Example orchestration for NIFTY option scalping with FYERS API.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from fyers_apiv2 import fyersModel
+
+from nifty_streamer import NiftyStreamer
+from nifty_signal_monitor import NiftySignalMonitor
+from option_selector import get_atm_option_symbol
+from option_trade_engine import OptionTradeEngine
+
+
+class ScalpingBot:
+    def __init__(self, access_token: str, client_id: str, qty: int = 50):
+        self.session = fyersModel.FyersModel(client_id=client_id, token=access_token)
+        self.streamer = NiftyStreamer(access_token)
+        self.monitor = NiftySignalMonitor()
+        self.trade_engine = OptionTradeEngine(self.session)
+        self.qty = qty
+
+    def start(self):
+        self.streamer.start()
+        threading.Thread(target=self.run_signals, daemon=True).start()
+
+    def run_signals(self):
+        while True:
+            signal = self.monitor.check_signal()
+            if signal and not self.trade_engine.active_trade:
+                ltp = self.session.quote(["NSE:NIFTY50-INDEX"])["d"][0]["v"][0]["last_traded_price"]
+                symbol = get_atm_option_symbol(ltp, "CE" if signal == "BUY" else "PE")
+                self.trade_engine.enter_trade(symbol, self.qty)
+                threading.Thread(target=self.trade_engine.run_trailing, daemon=True).start()
+            time.sleep(60)
+
+
+if __name__ == "__main__":
+    ACCESS_TOKEN = "YOUR_TOKEN_HERE"
+    CLIENT_ID = "YOUR_CLIENT_ID"
+
+    bot = ScalpingBot(ACCESS_TOKEN, CLIENT_ID)
+    bot.start()
+    while True:
+        time.sleep(1)

--- a/nifty_signal_monitor.py
+++ b/nifty_signal_monitor.py
@@ -1,0 +1,39 @@
+"""nifty_signal_monitor.py
+
+Calculate EMA based buy/sell signals from NIFTY tick data.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+from pandas import DataFrame
+
+
+class NiftySignalMonitor:
+    """Reads tick data, constructs candles and generates trade signals."""
+
+    def __init__(self, data_file: str = "nifty_tick_data.csv"):
+        self.data_file = data_file
+        self.last_signal: str | None = None
+
+    def _load_candles(self) -> DataFrame:
+        df = pd.read_csv(self.data_file, names=["timestamp", "ltp"])
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
+        df.set_index("timestamp", inplace=True)
+        candles = df["ltp"].resample("3min").last().dropna()
+        return candles.to_frame("close")
+
+    def check_signal(self) -> str | None:
+        candles = self._load_candles()
+        if len(candles) < 26:
+            return None
+        candles["ema9"] = candles["close"].ewm(span=9).mean()
+        candles["ema26"] = candles["close"].ewm(span=26).mean()
+        last = candles.iloc[-1]
+        if last["ema9"] > last["ema26"] and self.last_signal != "BUY":
+            self.last_signal = "BUY"
+            return "BUY"
+        if last["ema9"] < last["ema26"] and self.last_signal != "SELL":
+            self.last_signal = "SELL"
+            return "SELL"
+        return None

--- a/nifty_streamer.py
+++ b/nifty_streamer.py
@@ -1,0 +1,47 @@
+"""nifty_streamer.py
+
+Stream NIFTY50 index ticks using the Fyers WebSocket API.
+Ticks are appended to a CSV file for use by the signal monitor.
+
+This module keeps the interface lightweight so it can be
+integrated into other scripts without major dependencies.
+"""
+
+from datetime import datetime
+import csv
+import threading
+from fyers_apiv2.Websocket import ws
+
+
+class NiftyStreamer:
+    """Streams NIFTY50 index LTP and saves ticks to CSV."""
+
+    def __init__(self, fyers_access_token: str, data_file: str = "nifty_tick_data.csv"):
+        self.token = fyers_access_token
+        self.data_file = data_file
+        self._socket = None
+        self.running = False
+
+    def on_message(self, message):
+        ltp = message.get("ltp")
+        if ltp is None:
+            return
+        timestamp = datetime.utcnow().isoformat()
+        with open(self.data_file, "a", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow([timestamp, ltp])
+
+    def start(self):
+        """Start streaming ticks in a background thread."""
+        self.running = True
+        self._socket = ws.FyersSocket(access_token=self.token, run_background=False, log_path="logs/")
+        self._socket.websocket_data = self.on_message
+        self._socket.subscribe(["NSE:NIFTY50-INDEX"])
+        thread = threading.Thread(target=self._socket.keep_running)
+        thread.daemon = True
+        thread.start()
+
+    def stop(self):
+        if self._socket:
+            self._socket.close()
+        self.running = False

--- a/option_selector.py
+++ b/option_selector.py
@@ -1,0 +1,21 @@
+"""option_selector.py
+
+Helpers to compute the at-the-money option symbol for NIFTY.
+"""
+
+from datetime import date
+
+
+def get_atm_option_symbol(nifty_ltp: float, option_type: str, expiry: str | None = None) -> str:
+    """Return the FYERS symbol for the ATM option.
+
+    Args:
+        nifty_ltp: Current NIFTY spot price.
+        option_type: "CE" or "PE".
+        expiry: Optional expiry string (YYYY-MM-DD). Defaults to current week.
+    """
+    nearest_50 = round(nifty_ltp / 50) * 50
+    if expiry is None:
+        today = date.today()
+        expiry = today.strftime("%Y-%m-%d")
+    return f"NSE:NIFTY{expiry}{nearest_50}{option_type}"

--- a/option_trade_engine.py
+++ b/option_trade_engine.py
@@ -1,0 +1,85 @@
+"""option_trade_engine.py
+
+Execute option trades and handle trailing stop-loss using Fyers API.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from fyers_apiv2 import fyersModel
+
+
+@dataclass
+class Trade:
+    order_id: str
+    sl_order_id: str
+    symbol: str
+    qty: int
+    sl_price: float
+
+
+class OptionTradeEngine:
+    def __init__(self, fyers: fyersModel.FyersModel, sl_buffer: float = 5.0):
+        self.fyers = fyers
+        self.sl_buffer = sl_buffer
+        self.active_trade: Optional[Trade] = None
+
+    def enter_trade(self, symbol: str, qty: int) -> None:
+        if self.active_trade:
+            return
+        order = {
+            "symbol": symbol,
+            "qty": qty,
+            "type": 2,  # market order
+            "side": 1,  # buy
+            "productType": "INTRADAY",
+        }
+        result = self.fyers.place_order(order)
+        order_id = result.get("id")
+        ltp = self.fyers.quote([symbol])["d"][0]["v"][0]["last_traded_price"]
+        sl_price = max(1.0, ltp - self.sl_buffer)
+        sl_order = {
+            "symbol": symbol,
+            "qty": qty,
+            "type": 3,  # sl-limit
+            "side": -1,
+            "productType": "INTRADAY",
+            "limitPrice": sl_price,
+            "stopPrice": sl_price,
+            "parent_order_id": order_id,
+        }
+        sl_res = self.fyers.place_order(sl_order)
+        sl_order_id = sl_res.get("id")
+        self.active_trade = Trade(order_id, sl_order_id, symbol, qty, sl_price)
+
+    def trail_stop(self) -> None:
+        if not self.active_trade:
+            return
+        trade = self.active_trade
+        ltp = self.fyers.quote([trade.symbol])["d"][0]["v"][0]["last_traded_price"]
+        new_sl = ltp - self.sl_buffer
+        if new_sl > trade.sl_price:
+            modify = {
+                "id": trade.sl_order_id,
+                "limitPrice": new_sl,
+                "stopPrice": new_sl,
+            }
+            self.fyers.modify_order(modify)
+            trade.sl_price = new_sl
+
+    def check_exit(self):
+        if not self.active_trade:
+            return
+        status = self.fyers.get_orderbook()
+        for order in status.get("orderBook", []):
+            if order.get("id") == self.active_trade.sl_order_id and order.get("status") == "Exited":
+                self.active_trade = None
+
+    def run_trailing(self, interval: int = 5):
+        while self.active_trade:
+            self.trail_stop()
+            self.check_exit()
+            time.sleep(interval)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,6 @@ streamlit
 requests
 beautifulsoup4
 playwright
+fyers-apiv2
+pandas
 


### PR DESCRIPTION
## Summary
- add new dependencies for FYERS API and pandas
- implement NIFTY tick streamer
- implement ATM option symbol selection helper
- add EMA-based signal monitor
- implement option trade engine with trailing SL
- provide orchestration script for scalping bot

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_683f43de2394833391481d1454f2a0c8